### PR TITLE
Use vue style for the code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ npm install --save vue-just-another-dropdown
 ## Usage
 ---------------
 
-```javascript
+```vue
 <script>
 import vue from 'vue';
 import Dropdown from 'vue-just-another-dropdown';
@@ -31,9 +31,7 @@ export default {
   },
 };
 </script>
-```
 
-```HTML
 <template>
   <div class="hello">    
     <Dropdown :options="cities" v-model="city" placeholder="City" style="width: 30%"/>


### PR DESCRIPTION
At the moment, the code block looks a bit weird because the `<script>` tags are highlighted in a weird way by the javascript highlighter. By configuring the style to `vue`, this improves the colors used by Github for the code.